### PR TITLE
Feat/76 forgot password

### DIFF
--- a/android-app/app/src/main/AndroidManifest.xml
+++ b/android-app/app/src/main/AndroidManifest.xml
@@ -41,6 +41,11 @@
             android:windowSoftInputMode="adjustResize" />
 
         <activity
+            android:name=".ui.auth.forgotpassword.ForgotPasswordActivity"
+            android:exported="false"
+            android:windowSoftInputMode="adjustResize" />
+
+        <activity
             android:name=".MainActivity"
             android:exported="false" />
 

--- a/android-app/app/src/main/java/com/midterm/team12345/ui/auth/LoginActivity.java
+++ b/android-app/app/src/main/java/com/midterm/team12345/ui/auth/LoginActivity.java
@@ -20,6 +20,7 @@ import com.midterm.team12345.MainActivity;
 import com.midterm.team12345.R;
 import com.midterm.team12345.data.repository.AuthRepositoryImpl;
 import com.midterm.team12345.databinding.ActivityLoginBinding;
+import com.midterm.team12345.ui.auth.forgotpassword.ForgotPasswordActivity;
 import com.midterm.team12345.utils.Resource;
 
 public class LoginActivity extends AppCompatActivity {
@@ -76,6 +77,10 @@ public class LoginActivity extends AppCompatActivity {
             } catch (Exception e) {
                 Toast.makeText(this, "RegisterActivity chưa sẵn sàng", Toast.LENGTH_SHORT).show();
             }
+        });
+
+        binding.tvForgotPassword.setOnClickListener(v -> {
+            startActivity(new Intent(LoginActivity.this, ForgotPasswordActivity.class));
         });
     }
 

--- a/android-app/app/src/main/java/com/midterm/team12345/ui/auth/forgotpassword/ForgotEmailFragment.java
+++ b/android-app/app/src/main/java/com/midterm/team12345/ui/auth/forgotpassword/ForgotEmailFragment.java
@@ -1,0 +1,63 @@
+package com.midterm.team12345.ui.auth.forgotpassword;
+
+import android.os.Bundle;
+import android.text.Editable;
+import android.text.TextWatcher;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import androidx.lifecycle.ViewModelProvider;
+import com.midterm.team12345.databinding.FragmentForgotEmailBinding;
+import com.midterm.team12345.ui.base.BaseFragment;
+import com.midterm.team12345.utils.Resource;
+
+public class ForgotEmailFragment extends BaseFragment<FragmentForgotEmailBinding, ForgotPasswordViewModel> {
+
+    @Override
+    protected FragmentForgotEmailBinding inflateBinding(LayoutInflater inflater, ViewGroup container) {
+        return FragmentForgotEmailBinding.inflate(inflater, container, false);
+    }
+
+    @Override
+    protected ForgotPasswordViewModel createViewModel() {
+        return new ViewModelProvider(requireActivity()).get(ForgotPasswordViewModel.class);
+    }
+
+    @Override
+    protected void setupViews() {
+        binding.etEmail.setText(viewModel.email.getValue());
+        
+        binding.etEmail.addTextChangedListener(new TextWatcher() {
+            @Override
+            public void beforeTextChanged(CharSequence s, int start, int count, int after) {}
+
+            @Override
+            public void onTextChanged(CharSequence s, int start, int before, int count) {
+                viewModel.setEmail(s.toString());
+                binding.btnNext.setEnabled(viewModel.isEmailValid());
+            }
+
+            @Override
+            public void afterTextChanged(Editable s) {}
+        });
+
+        binding.btnNext.setEnabled(viewModel.isEmailValid());
+        binding.btnNext.setOnClickListener(v -> viewModel.requestForgotPassword());
+
+        binding.etEmail.requestFocus();
+    }
+
+    @Override
+    protected void observeViewModel() {
+        super.observeViewModel();
+        viewModel.forgotPasswordResult.observe(getViewLifecycleOwner(), resource -> {
+            if (resource.status == Resource.Status.SUCCESS) {
+                if (getActivity() instanceof ForgotPasswordActivity) {
+                    ((ForgotPasswordActivity) getActivity()).replaceFragment(new ForgotOtpFragment(), true);
+                }
+            } else if (resource.status == Resource.Status.ERROR) {
+                binding.tilEmail.setError(resource.message);
+            }
+        });
+    }
+}

--- a/android-app/app/src/main/java/com/midterm/team12345/ui/auth/forgotpassword/ForgotOtpFragment.java
+++ b/android-app/app/src/main/java/com/midterm/team12345/ui/auth/forgotpassword/ForgotOtpFragment.java
@@ -1,0 +1,79 @@
+package com.midterm.team12345.ui.auth.forgotpassword;
+
+import android.os.Bundle;
+import android.text.Editable;
+import android.text.TextWatcher;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.TextView;
+import androidx.lifecycle.ViewModelProvider;
+import com.midterm.team12345.databinding.FragmentForgotOtpBinding;
+import com.midterm.team12345.ui.base.BaseFragment;
+
+public class ForgotOtpFragment extends BaseFragment<FragmentForgotOtpBinding, ForgotPasswordViewModel> {
+
+    private TextView[] otpBoxes;
+
+    @Override
+    protected FragmentForgotOtpBinding inflateBinding(LayoutInflater inflater, ViewGroup container) {
+        return FragmentForgotOtpBinding.inflate(inflater, container, false);
+    }
+
+    @Override
+    protected ForgotPasswordViewModel createViewModel() {
+        return new ViewModelProvider(requireActivity()).get(ForgotPasswordViewModel.class);
+    }
+
+    @Override
+    protected void setupViews() {
+        binding.tvEmail.setText(viewModel.email.getValue());
+
+        otpBoxes = new TextView[]{
+                binding.tvOtp1, binding.tvOtp2, binding.tvOtp3,
+                binding.tvOtp4, binding.tvOtp5, binding.tvOtp6
+        };
+
+        binding.etOtp.addTextChangedListener(new TextWatcher() {
+            @Override
+            public void beforeTextChanged(CharSequence s, int start, int count, int after) {}
+
+            @Override
+            public void onTextChanged(CharSequence s, int start, int before, int count) {
+                String otp = s.toString();
+                for (int i = 0; i < otpBoxes.length; i++) {
+                    if (i < otp.length()) {
+                        otpBoxes[i].setText(String.valueOf(otp.charAt(i)));
+                        otpBoxes[i].setTextColor(getResources().getColor(android.R.color.black));
+                    } else {
+                        otpBoxes[i].setText("_");
+                        otpBoxes[i].setTextColor(getResources().getColor(android.R.color.darker_gray));
+                    }
+                }
+                viewModel.setOtpCode(otp);
+                binding.btnNext.setEnabled(viewModel.isOtpValid());
+            }
+
+            @Override
+            public void afterTextChanged(Editable s) {}
+        });
+
+        binding.btnNext.setEnabled(viewModel.isOtpValid());
+        binding.btnNext.setOnClickListener(v -> {
+            if (getActivity() instanceof ForgotPasswordActivity) {
+                ((ForgotPasswordActivity) getActivity()).replaceFragment(new ForgotPasswordFragment(), true);
+            }
+        });
+
+        binding.btnResend.setOnClickListener(v -> viewModel.requestForgotPassword());
+
+        // Focus and show keyboard
+        binding.etOtp.requestFocus();
+        binding.llOtpContainer.setOnClickListener(v -> {
+            binding.etOtp.requestFocus();
+            android.view.inputmethod.InputMethodManager imm = (android.view.inputmethod.InputMethodManager) 
+                    requireContext().getSystemService(android.content.Context.INPUT_METHOD_SERVICE);
+            imm.showSoftInput(binding.etOtp, android.view.inputmethod.InputMethodManager.SHOW_IMPLICIT);
+        });
+    }
+}

--- a/android-app/app/src/main/java/com/midterm/team12345/ui/auth/forgotpassword/ForgotPasswordActivity.java
+++ b/android-app/app/src/main/java/com/midterm/team12345/ui/auth/forgotpassword/ForgotPasswordActivity.java
@@ -1,0 +1,77 @@
+package com.midterm.team12345.ui.auth.forgotpassword;
+
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.inputmethod.InputMethodManager;
+import androidx.fragment.app.Fragment;
+import androidx.fragment.app.FragmentTransaction;
+import androidx.lifecycle.ViewModelProvider;
+import com.midterm.team12345.R;
+import com.midterm.team12345.data.repository.AuthRepositoryImpl;
+import com.midterm.team12345.databinding.ActivityForgotPasswordBinding;
+import com.midterm.team12345.ui.base.BaseActivity;
+
+public class ForgotPasswordActivity extends BaseActivity<ActivityForgotPasswordBinding, ForgotPasswordViewModel> {
+
+    @Override
+    protected ActivityForgotPasswordBinding inflateBinding(LayoutInflater inflater) {
+        return ActivityForgotPasswordBinding.inflate(inflater);
+    }
+
+    @Override
+    protected ForgotPasswordViewModel createViewModel() {
+        ForgotPasswordViewModelFactory factory = new ForgotPasswordViewModelFactory(
+                AuthRepositoryImpl.getInstance(getApplication())
+        );
+        return new ViewModelProvider(this, factory).get(ForgotPasswordViewModel.class);
+    }
+
+    @Override
+    protected void setupViews() {
+        setSupportActionBar(binding.toolbar);
+        if (getSupportActionBar() != null) {
+            getSupportActionBar().setDisplayShowTitleEnabled(false);
+        }
+
+        binding.toolbar.setNavigationOnClickListener(v -> onBackPressed());
+
+        if (getSupportFragmentManager().findFragmentById(R.id.fragment_container) == null) {
+            replaceFragment(new ForgotEmailFragment(), false);
+        }
+    }
+
+    @Override
+    protected void observeViewModel() {
+        super.observeViewModel();
+        viewModel.isLoading.observe(this, isLoading -> {
+            binding.progressBar.setVisibility(isLoading ? View.VISIBLE : View.GONE);
+        });
+    }
+
+    public void replaceFragment(Fragment fragment, boolean addToBackStack) {
+        FragmentTransaction transaction = getSupportFragmentManager().beginTransaction()
+                .replace(R.id.fragment_container, fragment);
+        if (addToBackStack) {
+            transaction.addToBackStack(null);
+        }
+        transaction.commit();
+        hideKeyboard();
+    }
+
+    private void hideKeyboard() {
+        View view = getCurrentFocus();
+        if (view != null) {
+            InputMethodManager imm = (InputMethodManager) getSystemService(INPUT_METHOD_SERVICE);
+            imm.hideSoftInputFromWindow(view.getWindowToken(), 0);
+        }
+    }
+
+    @Override
+    public void onBackPressed() {
+        if (getSupportFragmentManager().getBackStackEntryCount() > 0) {
+            getSupportFragmentManager().popBackStack();
+        } else {
+            super.onBackPressed();
+        }
+    }
+}

--- a/android-app/app/src/main/java/com/midterm/team12345/ui/auth/forgotpassword/ForgotPasswordFragment.java
+++ b/android-app/app/src/main/java/com/midterm/team12345/ui/auth/forgotpassword/ForgotPasswordFragment.java
@@ -1,0 +1,65 @@
+package com.midterm.team12345.ui.auth.forgotpassword;
+
+import android.os.Bundle;
+import android.text.Editable;
+import android.text.TextWatcher;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Toast;
+import androidx.lifecycle.ViewModelProvider;
+import com.midterm.team12345.databinding.FragmentForgotPasswordBinding;
+import com.midterm.team12345.ui.base.BaseFragment;
+import com.midterm.team12345.utils.Resource;
+
+public class ForgotPasswordFragment extends BaseFragment<FragmentForgotPasswordBinding, ForgotPasswordViewModel> {
+
+    @Override
+    protected FragmentForgotPasswordBinding inflateBinding(LayoutInflater inflater, ViewGroup container) {
+        return FragmentForgotPasswordBinding.inflate(inflater, container, false);
+    }
+
+    @Override
+    protected ForgotPasswordViewModel createViewModel() {
+        return new ViewModelProvider(requireActivity()).get(ForgotPasswordViewModel.class);
+    }
+
+    @Override
+    protected void setupViews() {
+        TextWatcher passwordWatcher = new TextWatcher() {
+            @Override
+            public void beforeTextChanged(CharSequence s, int start, int count, int after) {}
+
+            @Override
+            public void onTextChanged(CharSequence s, int start, int before, int count) {
+                viewModel.setNewPassword(binding.etPassword.getText().toString());
+                viewModel.setConfirmPassword(binding.etConfirmPassword.getText().toString());
+                binding.btnVerify.setEnabled(viewModel.isPasswordValid());
+            }
+
+            @Override
+            public void afterTextChanged(Editable s) {}
+        };
+
+        binding.etPassword.addTextChangedListener(passwordWatcher);
+        binding.etConfirmPassword.addTextChangedListener(passwordWatcher);
+
+        binding.btnVerify.setEnabled(viewModel.isPasswordValid());
+        binding.btnVerify.setOnClickListener(v -> viewModel.resetPassword());
+
+        binding.etPassword.requestFocus();
+    }
+
+    @Override
+    protected void observeViewModel() {
+        super.observeViewModel();
+        viewModel.resetPasswordResult.observe(getViewLifecycleOwner(), resource -> {
+            if (resource.status == Resource.Status.SUCCESS) {
+                Toast.makeText(requireContext(), "Đổi mật khẩu thành công", Toast.LENGTH_SHORT).show();
+                requireActivity().finish();
+            } else if (resource.status == Resource.Status.ERROR) {
+                showError(resource.message);
+            }
+        });
+    }
+}

--- a/android-app/app/src/main/java/com/midterm/team12345/ui/auth/forgotpassword/ForgotPasswordViewModel.java
+++ b/android-app/app/src/main/java/com/midterm/team12345/ui/auth/forgotpassword/ForgotPasswordViewModel.java
@@ -1,0 +1,116 @@
+package com.midterm.team12345.ui.auth.forgotpassword;
+
+import androidx.lifecycle.LiveData;
+import androidx.lifecycle.MutableLiveData;
+
+import com.midterm.team12345.data.remote.dto.request.ForgotPasswordRequestDTO;
+import com.midterm.team12345.data.remote.dto.request.ResetPasswordRequestDTO;
+import com.midterm.team12345.data.remote.dto.response.ForgotPasswordResponseDTO;
+import com.midterm.team12345.domain.repository.AuthRepository;
+import com.midterm.team12345.ui.base.BaseViewModel;
+import com.midterm.team12345.utils.Resource;
+
+public class ForgotPasswordViewModel extends BaseViewModel {
+    private final AuthRepository authRepository;
+
+    private final MutableLiveData<String> _email = new MutableLiveData<>("");
+    public final LiveData<String> email = _email;
+
+    private final MutableLiveData<String> _otpCode = new MutableLiveData<>("");
+    public final LiveData<String> otpCode = _otpCode;
+
+    private final MutableLiveData<String> _newPassword = new MutableLiveData<>("");
+    public final LiveData<String> newPassword = _newPassword;
+
+    private final MutableLiveData<String> _confirmPassword = new MutableLiveData<>("");
+    public final LiveData<String> confirmPassword = _confirmPassword;
+
+    private final MutableLiveData<Resource<ForgotPasswordResponseDTO>> _forgotPasswordResult = new MutableLiveData<>();
+    public final LiveData<Resource<ForgotPasswordResponseDTO>> forgotPasswordResult = _forgotPasswordResult;
+
+    private final MutableLiveData<Resource<ForgotPasswordResponseDTO>> _resetPasswordResult = new MutableLiveData<>();
+    public final LiveData<Resource<ForgotPasswordResponseDTO>> resetPasswordResult = _resetPasswordResult;
+
+    public ForgotPasswordViewModel(AuthRepository authRepository) {
+        this.authRepository = authRepository;
+    }
+
+    public void setEmail(String email) {
+        _email.setValue(email);
+    }
+
+    public void setOtpCode(String otp) {
+        _otpCode.setValue(otp);
+    }
+
+    public void setNewPassword(String password) {
+        _newPassword.setValue(password);
+    }
+
+    public void setConfirmPassword(String password) {
+        _confirmPassword.setValue(password);
+    }
+
+    public boolean isEmailValid() {
+        String emailStr = _email.getValue();
+        return emailStr != null && android.util.Patterns.EMAIL_ADDRESS.matcher(emailStr).matches();
+    }
+
+    public boolean isPasswordValid() {
+        String passwordStr = _newPassword.getValue();
+        String confirmStr = _confirmPassword.getValue();
+        return passwordStr != null && passwordStr.length() >= 8 && passwordStr.equals(confirmStr);
+    }
+
+    public boolean isOtpValid() {
+        String otpStr = _otpCode.getValue();
+        return otpStr != null && otpStr.length() == 6;
+    }
+
+    public void requestForgotPassword() {
+        if (!isEmailValid()) {
+            _errorMessage.setValue("Invalid email format");
+            return;
+        }
+
+        ForgotPasswordRequestDTO request = new ForgotPasswordRequestDTO(_email.getValue());
+        _forgotPasswordResult.setValue(Resource.loading(null));
+        _isLoading.setValue(true);
+        
+        authRepository.forgotPassword(request).observeForever(resource -> {
+            _forgotPasswordResult.setValue(resource);
+            if (resource.status != Resource.Status.LOADING) {
+                _isLoading.setValue(false);
+            }
+            if (resource.status == Resource.Status.ERROR) {
+                _errorMessage.setValue(resource.message);
+            }
+        });
+    }
+
+    public void resetPassword() {
+        if (!isEmailValid() || !isOtpValid() || !isPasswordValid()) {
+            _errorMessage.setValue("Please check your input");
+            return;
+        }
+
+        ResetPasswordRequestDTO request = new ResetPasswordRequestDTO(
+                _email.getValue(),
+                _otpCode.getValue(),
+                _newPassword.getValue()
+        );
+
+        _resetPasswordResult.setValue(Resource.loading(null));
+        _isLoading.setValue(true);
+
+        authRepository.resetPassword(request).observeForever(resource -> {
+            _resetPasswordResult.setValue(resource);
+            if (resource.status != Resource.Status.LOADING) {
+                _isLoading.setValue(false);
+            }
+            if (resource.status == Resource.Status.ERROR) {
+                _errorMessage.setValue(resource.message);
+            }
+        });
+    }
+}

--- a/android-app/app/src/main/java/com/midterm/team12345/ui/auth/forgotpassword/ForgotPasswordViewModelFactory.java
+++ b/android-app/app/src/main/java/com/midterm/team12345/ui/auth/forgotpassword/ForgotPasswordViewModelFactory.java
@@ -1,0 +1,25 @@
+package com.midterm.team12345.ui.auth.forgotpassword;
+
+import androidx.annotation.NonNull;
+import androidx.lifecycle.ViewModel;
+import androidx.lifecycle.ViewModelProvider;
+
+import com.midterm.team12345.domain.repository.AuthRepository;
+
+public class ForgotPasswordViewModelFactory implements ViewModelProvider.Factory {
+    private final AuthRepository authRepository;
+
+    public ForgotPasswordViewModelFactory(AuthRepository authRepository) {
+        this.authRepository = authRepository;
+    }
+
+    @NonNull
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T extends ViewModel> T create(@NonNull Class<T> modelClass) {
+        if (modelClass.isAssignableFrom(ForgotPasswordViewModel.class)) {
+            return (T) new ForgotPasswordViewModel(authRepository);
+        }
+        throw new IllegalArgumentException("Unknown ViewModel class");
+    }
+}

--- a/android-app/app/src/main/res/drawable/bg_otp_box.xml
+++ b/android-app/app/src/main/res/drawable/bg_otp_box.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/white" />
+    <stroke android:width="1dp" android:color="#E5E5EA" />
+    <corners android:radius="12dp" />
+</shape>

--- a/android-app/app/src/main/res/layout/activity_forgot_password.xml
+++ b/android-app/app/src/main/res/layout/activity_forgot_password.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/white">
+
+    <com.google.android.material.appbar.MaterialToolbar
+        android:id="@+id/toolbar"
+        android:layout_width="match_parent"
+        android:layout_height="?attr/actionBarSize"
+        android:background="@color/white"
+        app:elevation="0dp"
+        app:layout_constraintTop_toTopOf="parent"
+        app:navigationIcon="@drawable/ic_back_arrow" />
+
+    <FrameLayout
+        android:id="@+id/fragment_container"
+        android:layout_width="match_parent"
+        android:layout_height="0dp"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/toolbar" />
+
+    <ProgressBar
+        android:id="@+id/progressBar"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:visibility="gone"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/android-app/app/src/main/res/layout/fragment_forgot_email.xml
+++ b/android-app/app/src/main/res/layout/fragment_forgot_email.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/white"
+    android:padding="24dp">
+
+    <TextView
+        android:id="@+id/tvTitle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="60dp"
+        android:text="Confirm it's you."
+        android:textColor="@color/black"
+        android:textSize="22sp"
+        android:textStyle="bold"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/tvSubtitle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="12dp"
+        android:text="Please verify your email to continue"
+        android:textColor="#8E8E93"
+        android:textSize="14sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tvTitle" />
+
+    <TextView
+        android:id="@+id/tvEmailLabel"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="80dp"
+        android:text="Email"
+        android:textColor="@color/black"
+        android:textSize="16sp"
+        android:textStyle="bold"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tvSubtitle" />
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/tilEmail"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        app:boxStrokeWidth="0dp"
+        app:boxStrokeWidthFocused="0dp"
+        app:hintEnabled="false"
+        app:layout_constraintTop_toBottomOf="@id/tvEmailLabel">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/etEmail"
+            android:layout_width="match_parent"
+            android:layout_height="56dp"
+            android:background="@drawable/bg_edit_text_rounded"
+            android:hint="example@gmail.com"
+            android:inputType="textEmailAddress"
+            android:paddingHorizontal="16dp"
+            android:textColor="@color/black" />
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/btnNext"
+        android:layout_width="match_parent"
+        android:layout_height="56dp"
+        android:layout_marginTop="32dp"
+        android:text="Continue"
+        android:textAllCaps="false"
+        android:textSize="16sp"
+        android:textStyle="bold"
+        app:backgroundTint="@color/messenger_blue"
+        app:cornerRadius="18dp"
+        app:layout_constraintTop_toBottomOf="@id/tilEmail" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/android-app/app/src/main/res/layout/fragment_forgot_otp.xml
+++ b/android-app/app/src/main/res/layout/fragment_forgot_otp.xml
@@ -1,0 +1,180 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/white"
+    android:padding="24dp">
+
+    <!-- Header Section -->
+    <LinearLayout
+        android:id="@+id/llHeader"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        app:layout_constraintTop_toTopOf="parent">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Please enter the code we sent to"
+            android:textColor="#8E8E93"
+            android:textSize="14sp" />
+
+        <TextView
+            android:id="@+id/tvEmail"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="example@gmail.com"
+            android:textColor="#3A3A3C"
+            android:textSize="14sp"
+            android:textStyle="bold" />
+    </LinearLayout>
+
+    <!-- Main Title -->
+    <TextView
+        android:id="@+id/tvTitle"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="60dp"
+        android:gravity="center"
+        android:text="Check your email for a\nverification link."
+        android:textColor="@color/black"
+        android:textSize="22sp"
+        android:textStyle="bold"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/llHeader" />
+
+    <!-- OTP Input Boxes - Always square and spans full width -->
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/llOtpContainer"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="48dp"
+        app:layout_constraintTop_toBottomOf="@id/tvTitle">
+
+        <TextView
+            android:id="@+id/tvOtp1"
+            style="@style/OtpBoxStyle"
+            android:layout_marginEnd="4dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintDimensionRatio="1:1"
+            app:layout_constraintEnd_toStartOf="@+id/tvOtp2"
+            app:layout_constraintHorizontal_weight="1"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/tvOtp2"
+            style="@style/OtpBoxStyle"
+            android:layout_marginHorizontal="4dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintDimensionRatio="1:1"
+            app:layout_constraintEnd_toStartOf="@+id/tvOtp3"
+            app:layout_constraintHorizontal_weight="1"
+            app:layout_constraintStart_toEndOf="@+id/tvOtp1"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/tvOtp3"
+            style="@style/OtpBoxStyle"
+            android:layout_marginHorizontal="4dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintDimensionRatio="1:1"
+            app:layout_constraintEnd_toStartOf="@+id/tvOtp4"
+            app:layout_constraintHorizontal_weight="1"
+            app:layout_constraintStart_toEndOf="@+id/tvOtp2"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/tvOtp4"
+            style="@style/OtpBoxStyle"
+            android:layout_marginHorizontal="4dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintDimensionRatio="1:1"
+            app:layout_constraintEnd_toStartOf="@+id/tvOtp5"
+            app:layout_constraintHorizontal_weight="1"
+            app:layout_constraintStart_toEndOf="@+id/tvOtp3"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/tvOtp5"
+            style="@style/OtpBoxStyle"
+            android:layout_marginHorizontal="4dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintDimensionRatio="1:1"
+            app:layout_constraintEnd_toStartOf="@+id/tvOtp6"
+            app:layout_constraintHorizontal_weight="1"
+            app:layout_constraintStart_toEndOf="@+id/tvOtp4"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <TextView
+            android:id="@+id/tvOtp6"
+            style="@style/OtpBoxStyle"
+            android:layout_marginStart="4dp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintDimensionRatio="1:1"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintHorizontal_weight="1"
+            app:layout_constraintStart_toEndOf="@+id/tvOtp5"
+            app:layout_constraintTop_toTopOf="parent" />
+
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <!-- Hidden EditText to handle keyboard input -->
+    <EditText
+        android:id="@+id/etOtp"
+        android:layout_width="1dp"
+        android:layout_height="1dp"
+        android:alpha="0"
+        android:background="@null"
+        android:cursorVisible="false"
+        android:inputType="number"
+        android:maxLength="6"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <!-- Action Button -->
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/btnNext"
+        android:layout_width="match_parent"
+        android:layout_height="56dp"
+        android:layout_marginTop="64dp"
+        android:text="Continue"
+        android:textAllCaps="false"
+        android:textSize="16sp"
+        android:textStyle="bold"
+        app:backgroundTint="@color/messenger_blue"
+        app:cornerRadius="18dp"
+        app:layout_constraintTop_toBottomOf="@id/llOtpContainer" />
+
+    <!-- Resend Link -->
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="24dp"
+        android:orientation="horizontal"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/btnNext">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Didn't get? "
+            android:textColor="#8E8E93"
+            android:textSize="14sp" />
+
+        <TextView
+            android:id="@+id/btnResend"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="Send me a new email"
+            android:textColor="@color/black"
+            android:textStyle="bold"
+            android:textSize="14sp"
+            android:background="?attr/selectableItemBackground" />
+    </LinearLayout>
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/android-app/app/src/main/res/layout/fragment_forgot_password.xml
+++ b/android-app/app/src/main/res/layout/fragment_forgot_password.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:background="@color/white"
+    android:padding="24dp">
+
+    <TextView
+        android:id="@+id/tvTitle"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="60dp"
+        android:text="Create a new password"
+        android:textColor="@color/black"
+        android:textSize="22sp"
+        android:textStyle="bold"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <TextView
+        android:id="@+id/tvSubtitle"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="12dp"
+        android:gravity="center"
+        android:text="Get chatting with friends and family today by\nsigning up for our chat app!"
+        android:textColor="#8E8E93"
+        android:textSize="14sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tvTitle" />
+
+    <TextView
+        android:id="@+id/tvPasswordLabel"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="60dp"
+        android:text="Password"
+        android:textColor="@color/messenger_blue"
+        android:textSize="14sp"
+        android:textStyle="bold"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tvSubtitle" />
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/tilPassword"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:hintEnabled="false"
+        app:endIconMode="password_toggle"
+        app:endIconTint="@color/messenger_blue"
+        app:layout_constraintTop_toBottomOf="@id/tvPasswordLabel">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/etPassword"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:backgroundTint="#E5E5EA"
+            android:hint="••••••••"
+            android:inputType="textPassword"
+            android:paddingVertical="12dp"
+            android:textColor="@color/black" />
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <TextView
+        android:id="@+id/tvConfirmPasswordLabel"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="32dp"
+        android:text="Confirm Password"
+        android:textColor="@color/messenger_blue"
+        android:textSize="14sp"
+        android:textStyle="bold"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/tilPassword" />
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/tilConfirmPassword"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        app:hintEnabled="false"
+        app:endIconMode="password_toggle"
+        app:endIconTint="@color/messenger_blue"
+        app:layout_constraintTop_toBottomOf="@id/tvConfirmPasswordLabel">
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/etConfirmPassword"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:backgroundTint="#E5E5EA"
+            android:hint="••••••••"
+            android:inputType="textPassword"
+            android:paddingVertical="12dp"
+            android:textColor="@color/black" />
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/btnVerify"
+        android:layout_width="match_parent"
+        android:layout_height="56dp"
+        android:layout_marginBottom="16dp"
+        android:text="Continue"
+        android:textAllCaps="false"
+        android:textSize="16sp"
+        android:textStyle="bold"
+        app:backgroundTint="@color/messenger_blue"
+        app:cornerRadius="18dp"
+        app:layout_constraintBottom_toBottomOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/android-app/app/src/main/res/values/styles.xml
+++ b/android-app/app/src/main/res/values/styles.xml
@@ -50,4 +50,17 @@
         <item name="android:textSize">16sp</item>
         <item name="android:maxLines">1</item>
     </style>
+
+    <style name="OtpBoxStyle">
+        <item name="android:layout_width">0dp</item>
+        <item name="android:layout_height">0dp</item>
+        <item name="android:background">@drawable/bg_otp_box</item>
+        <item name="android:gravity">center</item>
+        <item name="android:textColor">@color/black</item>
+        <item name="android:textSize">22sp</item>
+        <item name="android:textStyle">bold</item>
+        <item name="android:text">_</item>
+        <item name="android:textColorHint">#8E8E93</item>
+        <item name="android:includeFontPadding">false</item>
+    </style>
 </resources>


### PR DESCRIPTION
1. Kiến trúc & Quản lý trạng thái
• Single Activity + Multiple Fragments: Triển khai ForgotPasswordActivity làm host, điều hướng qua 3 bước (Email ➡️ OTP ➡️ Reset Password).
• Shared ViewModel (Activity-scoped): Sử dụng ForgotPasswordViewModel để lưu trữ dữ liệu (email, otpCode, newPassword) xuyên suốt luồng wizard, đảm bảo không mất dữ liệu khi người dùng nhấn Back.
2. Chi tiết các màn hình (Fragments)
• ForgotEmailFragment:
◦ Nhập và validate định dạng Email.
◦ Gọi API gửi mã OTP. Tự động focus ô nhập liệu khi mở màn hình.
• ForgotOtpFragment:
◦ Giao diện nhập 6 chữ số OTP với các ô nhập là hình vuông hoàn hảo (tỷ lệ 1:1).
◦ Dải ô OTP tự động co giãn và trải rộng ngang bằng với các trường input khác trên mọi kích thước màn hình.
◦ Sử dụng EditText ẩn để xử lý nhập liệu từ bàn phím hệ thống.
• ForgotPasswordFragment:
◦ Nhập mật khẩu mới và xác nhận mật khẩu.
◦ Tích hợp tính năng ẩn/hiện mật khẩu (Password Toggle).
◦ Validate mật khẩu khớp và đủ độ dài (>= 8 ký tự).